### PR TITLE
Move indexing section header

### DIFF
--- a/R-Series-1-An_Intro_to_R-Code-.R
+++ b/R-Series-1-An_Intro_to_R-Code-.R
@@ -243,6 +243,10 @@ clock_sounds <- rep(c("tick", "tock"), 3) # REPeats the vector c("tick", "tock")
 
 print(length(planets)) # Prints "8"
 
+# ---------------------------------------------------------
+# Section 5b: Index positions
+# ---------------------------------------------------------
+
 ######## You can get elements of a vector by indexing, using [] notation.
 ######## Note that R, unlike many languages, uses 1-indexing rather than 0-indexing.
 ######## This means that the first element of a vector has index 1.
@@ -250,10 +254,6 @@ print(length(planets)) # Prints "8"
 print(planets[1]) # Prints "mercury"
 planet_4 <- planets[4]
 print(planet_4)   # Prints "mars"
-
-# ---------------------------------------------------------
-# Section 5b: Index positions
-# ---------------------------------------------------------
 
 ######## You can also index multiple elements at once. There are two main ways of doing this - with
 ########    a vector of "index positions", and with a vector of logicals.


### PR DESCRIPTION
Move the section header for `section 5b` up, to include the introduction to indices.

Not sure what's going on with the change at line `858`, possibly a newline character/end of file issue.